### PR TITLE
Fix Config import to use ConfigType instead

### DIFF
--- a/custom_components/noaa_space_weather/__init__.py
+++ b/custom_components/noaa_space_weather/__init__.py
@@ -10,11 +10,11 @@ import logging
 from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
@@ -30,7 +30,7 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 PLATFORM_SCHEMA = cv.platform_only_config_schema(DOMAIN)
 
 
-async def async_setup(hass: HomeAssistant, config: Config):
+async def async_setup(hass: HomeAssistant, config: ConfigType):
     """Set up this integration using YAML is not supported."""
     return True
 


### PR DESCRIPTION
This integration will break on HA 2024.11 due to https://github.com/home-assistant/core/pull/129163
It seems like Config was only used for (incorrect) typing; this fix is backwards compatible.