### PR TITLE
PR to update manifest file to be aligned with latest release 2.0.4.

### DIFF
--- a/custom_components/noaa_space_weather/manifest.json
+++ b/custom_components/noaa_space_weather/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/tcarwash/home-assistant_noaa-space-weather/issues",
   "requirements": ["swpclib>=4.2.0"],
-  "version": "2.0.1"
+  "version": "2.0.4"
 }


### PR DESCRIPTION
Full commit mesage: Manifest fill still showed 2.0.1 as the version despite all the code being updated to 2.0.4's release. This was likely causing a mismatch and confusion in Home Assistant, which is why people thought it broke. Code itself wasn't broken at all, just the manifest needed to be updated.

Fixes issue #65 
